### PR TITLE
Add run exports to flatbuffers 2.X

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "22.12.06" %}
+{% set version = "2.0.8" %}
 
 package:
   name: flatbuffers
@@ -6,10 +6,12 @@ package:
 
 source:
   url: https://github.com/google/flatbuffers/archive/v{{ version }}.tar.gz
-  sha256: 209823306f2cbedab6ff70997e0d236fcfd1864ca9ad082cbfdb196e7386daed
+  sha256: f97965a727d26386afaefff950badef2db3ab6af9afe23ed6d94bfb65f95f37e
 
 build:
-  number: 0
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('flatbuffers', max_pin='x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
This should have a new branch created.

I don't think we should maintain the 2 branch at infinitum, but I think it will help users make recepies in the short term that still need the 2 version of this package (maybe)

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
